### PR TITLE
Better specify repository name constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,12 @@ Note: leading/trailing whitespace will still validate, they will just be trimmed
 
 #### Repository names
 
-- Max length: 100 characters
-- All characters must be either a hyphen (`-`), a period (`.`), or alphanumeric
+- Max length: 100 code points
+- All code points must be either a hyphen (`-`), an underscore (`_`), a period (`.`), or an ASCII alphanumeric code point
 - Must be unique per-user and/or per-organization
+
+Note: sequences of invalid code points are automatically replaced by a single hyphen (`-`)
+Note: length checking is performed after replacement
 
 *This was verified through checking automatically-generated aliases with repository names.*
 


### PR DESCRIPTION
* swap "character" for "codepoint" for better precision as that seems like what github works with
* adds the underscore (`_`) which was missing from the list of valids
* clarify that "alphanumeric" is ascii-only not e.g. unicode categories
* specifies that github automatically replaces *sequences* of invalid codepoints by a single hyphen (so `'a'` followed by 150 emoji followed by `'z'` is the valid repository name `a-z`)
* left implied: github does not perform any normalisation (or denormalisation) before sanitisation

Closes #3