### PR TITLE
Note Restriction on Repositories Called `.`

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Note: leading/trailing whitespace will still validate, they will just be trimmed
 - Max length: 100 code points
 - All code points must be either a hyphen (`-`), an underscore (`_`), a period (`.`), or an ASCII alphanumeric code point
 - Must be unique per-user and/or per-organization
-- The repository name containing a single period (`.`) is reserved
+- The repository names containing only a single period (`.`) or double period (`..`) are reserved
 
 Note: sequences of invalid code points are automatically replaced by a single hyphen (`-`)
 Note: length checking is performed after replacement

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Note: leading/trailing whitespace will still validate, they will just be trimmed
 - Max length: 100 code points
 - All code points must be either a hyphen (`-`), an underscore (`_`), a period (`.`), or an ASCII alphanumeric code point
 - Must be unique per-user and/or per-organization
+- The repository name containing a single period (`.`) is reserved
 
 Note: sequences of invalid code points are automatically replaced by a single hyphen (`-`)
 Note: length checking is performed after replacement


### PR DESCRIPTION
A small edge case related to repository names is the case of a single period (`.`) or double period (`..`). When you attempt to create such a repository using the GitHub UI, it presents an error "The repository . is reserved".

<img width="291" alt="image" src="https://user-images.githubusercontent.com/2789166/154128668-1957ac7a-528d-4ffe-957b-a204b8ae192c.png">

This PR makes a note of that case, in case anyone runs into it.