### PR TITLE
Update issue title limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Note: length checking is performed after replacement
 #### Issue title
 
 - Min length: 1 character
-- Max length: 256 characters
+- Max length: 1024 characters
 
 *The first verified by creating an issue with a very long title and confirmed with an error message.*
 


### PR DESCRIPTION
Even if the error message still displays "maximum is 256 characters," I have been able to create issues with titles that are 1024 characters long.

Try the following:
```
Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla ac euismod diam, eu rutrum ipsum. Phasellus eu sodales risus. Mauris porttitor, dui interdum lobortis finibus, leo lacus euismod ex, sit amet vulputate ligula neque sit amet nisl. Aenean lobortis libero molestie imperdiet bibendum. Cras mattis massa vitae ipsum consectetur dictum. Aliquam libero massa, laoreet tincidunt quam at, ultrices laoreet metus. Nullam non turpis nec velit hendrerit dignissim sit amet id turpis. Maecenas felis ipsum, venenatis nec elementum ac, pulvinar in risus. Etiam lobortis nisl ac est placerat condimentum. Aliquam erat volutpat. Vestibulum ac ullamcorper est, ut commodo dolor. Nunc dapibus leo nec erat ullamcorper mattis. Ut luctus diam vitae enim posuere, ac egestas lacus mattis. Morbi eu ornare sem. Suspendisse potenti. Vestibulum convallis pellentesque nisl placerat lacinia. In at magna elementum, efficitur metus in, iaculis dolor. Phasellus vel neque purus. Sed vitae augue sodales, egestas dolor at, vestibulum qua.
```

![image](https://github.com/dead-claudia/github-limits/assets/22526783/fbff15c9-cee9-47f7-add4-94afa4b02c23)
