### PR TITLE
Constraint update: body is optional on issues as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,11 @@ Note: length checking is performed after replacement
 
 #### Issue description
 
-- Min length: 1 character
+- Min length: 0 characters
 - Max length: 65536 characters
 
-*The first verified by creating an issue with a very long description and confirmed with an error message.*
+*The first was verified by creating an issue with an empty description in the UI*
+*The second verified by creating an issue with a very long description and confirmed with an error message.*
 
 
 #### PR body 


### PR DESCRIPTION
- the body can be left empty when creating an issue via the UI (cf xmo-odoo/messages#3)
- the `body` is documented as optional in the v3 API: https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#create-an-issue--parameters
- when creating an issue via the API, the body can be left out or set to `""` (an empty string), which in both cases will succeed and result in an issue with a `{"body":null}`