### PR TITLE
Add limits for issue comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Note: length checking is performed after replacement
 #### Issue description
 
 - Min length: 1 character
-- Max length: 65536 characters
+- Max length: 65536 codepoints
 
 *The first verified by creating an issue with a very long description and confirmed with an error message.*
 
@@ -122,7 +122,7 @@ Note: length checking is performed after replacement
 #### PR body 
 
 - Min length: 0 characters
-- Max length: 262144 bytes
+- Max length: 65536 codepoints
 
 *This was verified by making PATCH requests to `/repos/{owner}/{repo}/pulls/{pull_number}` with `"body"` in body. This was also verified by adding longer body (262,145 characters) to a PR body in UI and confirmed with the error: `There was an error posting your comment: Body is too long`.*
 

--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ Note: length checking is performed after replacement
 
 ### Issue comments
 
-- min length: 1 character
-- Max length: 262144 bytes (65536~262144 characters depending on utf8-encoded size)
+- Min length: 1 character
+- Max length: 262144 bytes (65536-262144 characters depending on UTF8-encoded size)
 
 *This was verified by POST-ing bodies of various sizes to a dummy issue via the V3 API.*
 

--- a/README.md
+++ b/README.md
@@ -122,10 +122,16 @@ Note: length checking is performed after replacement
 #### PR body 
 
 - Min length: 0 characters
-- Max length: 262144 characters
+- Max length: 262144 bytes
 
 *This was verified by making PATCH requests to `/repos/{owner}/{repo}/pulls/{pull_number}` with `"body"` in body. This was also verified by adding longer body (262,145 characters) to a PR body in UI and confirmed with the error: `There was an error posting your comment: Body is too long`.*
 
+### Issue comments
+
+- min length: 1 character
+- Max length: 262144 bytes (65536~262144 characters depending on utf8-encoded size)
+
+*This was verified by POST-ing bodies of various sizes to a dummy issue via the V3 API.*
 
 #### List of starred items
 


### PR DESCRIPTION
When exceeding the allowable size, the error response claims that

> maximum is 65536 characters

but this seems to be off of emoji in the astral plane (which require 4 bytes in UTF-8):

- when posting pure ASCII, 262144 characters are allowed but 262145 are not
- when posting 🌈, 65536 occurrences (== 262144 bytes once encoded) are allowed but adding one ascii character to that (262145 bytes) is rejected.

Though I have not validated it I assume PR bodies have the same constraints so updated the qualifier there.